### PR TITLE
don't include duplicate imports

### DIFF
--- a/block_import.go
+++ b/block_import.go
@@ -57,7 +57,7 @@ func newImportsBlock() *importsBlock {
 
 func (i *importsBlock) write(sb *strings.Builder) {
 	if count := len(i.lines); count == 0 {
-		Return()
+		return
 	} else {
 		keys := make([]string, 0, len(i.lines))
 		for k := range i.lines {

--- a/block_import.go
+++ b/block_import.go
@@ -14,20 +14,20 @@ type importsBlock struct {
 // Imports creates a new imports block
 func (f *File) Imports(imports ...*importLine) *importsBlock {
 	for _, value := range imports {
-		f.imports.lines[value.path] = value
+		f.imports.addImport(value)
 	}
 
 	return f.imports
 }
 
 // AddImport adds a new import statement to the import block
-func (i *importsBlock) AddImport(path string) {
-	i.lines[path] = Import(path)
+func (i *importsBlock) AddImport(path string) *importLine {
+	return i.addImport(Import(path))
 }
 
 // AddImportAlias adds a new import statement with its package alias to the import block
-func (i *importsBlock) AddImportAlias(path, alias string) {
-	i.lines[path] = ImportAlias(path, alias)
+func (i *importsBlock) AddImportAlias(path, alias string) *importLine {
+	return i.addImport(ImportAlias(path, alias))
 }
 
 // Import creates a new import statemet without an alias
@@ -38,6 +38,15 @@ func Import(path string) *importLine {
 // ImportAlias creates a new import statement with an alias
 func ImportAlias(path, alias string) *importLine {
 	return &importLine{path: path, alias: alias}
+}
+
+func (i *importsBlock) addImport(line *importLine) *importLine {
+	if existing, ok := i.lines[line.path]; ok {
+		return existing
+	} else {
+		i.lines[line.path] = line
+		return line
+	}
 }
 
 func newImportsBlock() *importsBlock {

--- a/block_import.go
+++ b/block_import.go
@@ -59,7 +59,7 @@ func (i *importsBlock) write(sb *strings.Builder) {
 	if count := len(i.lines); count == 0 {
 		return
 	} else {
-		keys := make([]string, 0, len(i.lines))
+		keys := make([]string, 0, count)
 		for k := range i.lines {
 			keys = append(keys, k)
 		}

--- a/block_import_test.go
+++ b/block_import_test.go
@@ -68,3 +68,51 @@ alias "path"
 
 	assert.Equal(t, want, sb.String())
 }
+
+func TestNotAddDuplicateImports(t *testing.T) {
+	const want = `import "path"
+`
+	var sb strings.Builder
+	fixture := newImportsBlock()
+	fixture.AddImport("path")
+	fixture.AddImport("path")
+	fixture.write(&sb)
+
+	assert.Equal(t, want, sb.String())
+}
+
+func TestNotAddDuplicateImportsAlias(t *testing.T) {
+	const want = `import "path"
+`
+	var sb strings.Builder
+	fixture := newImportsBlock()
+	fixture.AddImport("path")
+	fixture.AddImportAlias("path", "alias")
+	fixture.write(&sb)
+
+	assert.Equal(t, want, sb.String())
+}
+
+func TestNotAddDuplicateImportsAliasFirst(t *testing.T) {
+	const want = `import alias "path"
+`
+	var sb strings.Builder
+	fixture := newImportsBlock()
+	fixture.AddImportAlias("path", "alias")
+	fixture.AddImport("path")
+	fixture.write(&sb)
+
+	assert.Equal(t, want, sb.String())
+}
+
+func TestNotAddDuplicateImportsAliasFirstAlias(t *testing.T) {
+	const want = `import alias "path"
+`
+	var sb strings.Builder
+	fixture := newImportsBlock()
+	fixture.AddImportAlias("path", "alias")
+	fixture.AddImportAlias("path", "alias")
+	fixture.write(&sb)
+
+	assert.Equal(t, want, sb.String())
+}

--- a/main_file.go
+++ b/main_file.go
@@ -42,12 +42,12 @@ func (f *File) Save(filePath string) error {
 
 // AddImport adds a new import statement to the import block
 func (f *File) AddImport(path string) {
-	f.imports.lines = append(f.imports.lines, Import(path))
+	f.imports.AddImport(path)
 }
 
 // AddImportAlias adds a new import statement with its package alias to the import block
 func (f *File) AddImportAlias(path, alias string) {
-	f.imports.lines = append(f.imports.lines, ImportAlias(path, alias))
+	f.imports.AddImportAlias(path, alias)
 }
 
 func (f *File) GoString() string {


### PR DESCRIPTION
Issue #30 

- store imports as a map (don't allow duplicate paths)
- iteration over the map is by keys (controlled, not random)