### PR TITLE
implement the cast syntax

### DIFF
--- a/value_call.go
+++ b/value_call.go
@@ -23,6 +23,26 @@ func (c *callValue) Call(funcName string) *callValue {
 	return newCallValue(c, funcName)
 }
 
+// Cast casts the return value of the call to the specified type
+func (c *callValue) Cast(typeName string) *castValue {
+	return newCastValue(c, "", typeName, false)
+}
+
+// CastPointer casts the return value of the call to a pointer of the specified type
+func (c *callValue) CastPointer(typeName string) *castValue {
+	return newCastValue(c, "", typeName, true)
+}
+
+// CastQual casts the return value of the call to the specified type with an alias
+func (c *callValue) CastQual(alias, typeName string) *castValue {
+	return newCastValue(c, alias, typeName, false)
+}
+
+// CastQualPointer casts the return value of the call to a pointer of the specified type with an alias
+func (c *callValue) CastQualPointer(alias, typeName string) *castValue {
+	return newCastValue(c, alias, typeName, true)
+}
+
 func newCallValue(val Value, funcName string) *callValue {
 	return &callValue{
 		val:        val,

--- a/value_call_test.go
+++ b/value_call_test.go
@@ -79,3 +79,47 @@ func TestCallAsStmt(t *testing.T) {
 	assert.False(t, got)
 	assert.Equal(t, want, sb.String())
 }
+
+func TestCallCast(t *testing.T) {
+	const want = `a.myFunc().(string)`
+
+	var sb strings.Builder
+	Identifier("a").Call("myFunc").
+		Cast("string").
+		writeValue(&sb)
+
+	assert.Equal(t, want, sb.String())
+}
+
+func TestCallCastPointer(t *testing.T) {
+	const want = `a.myFunc().(*string)`
+
+	var sb strings.Builder
+	Identifier("a").Call("myFunc").
+		CastPointer("string").
+		writeValue(&sb)
+
+	assert.Equal(t, want, sb.String())
+}
+
+func TestCallCastQual(t *testing.T) {
+	const want = `a.myFunc().(alias.MyType)`
+
+	var sb strings.Builder
+	Identifier("a").Call("myFunc").
+		CastQual("alias", "MyType").
+		writeValue(&sb)
+
+	assert.Equal(t, want, sb.String())
+}
+
+func TestCallCastQualPointer(t *testing.T) {
+	const want = `a.myFunc().(*alias.MyType)`
+
+	var sb strings.Builder
+	Identifier("a").Call("myFunc").
+		CastQualPointer("alias", "MyType").
+		writeValue(&sb)
+
+	assert.Equal(t, want, sb.String())
+}

--- a/value_cast.go
+++ b/value_cast.go
@@ -1,0 +1,39 @@
+package codegen
+
+import "strings"
+
+type castValue struct {
+	val     Value
+	name    *nameHelper
+	pointer bool
+}
+
+// Pointer turns the cast value into a pointer
+func (c *castValue) Pointer() *castValue {
+	c.pointer = true
+	return c
+}
+
+func newCastValue(val Value, alias, typeName string, isPointer bool) *castValue {
+	return &castValue{
+		val: val,
+		name: &nameHelper{
+			alias:      alias,
+			identifier: typeName,
+			isPointer:  isPointer,
+		},
+	}
+}
+
+func (c *castValue) writeValue(sb *strings.Builder) {
+	writePointerValueAccess(sb, c.val)
+	sb.WriteString(".(")
+
+	c.name.writeValue(sb)
+
+	sb.WriteByte(')')
+}
+
+func (c *castValue) isPointer() bool {
+	return c.pointer
+}

--- a/value_cast.go
+++ b/value_cast.go
@@ -3,15 +3,8 @@ package codegen
 import "strings"
 
 type castValue struct {
-	val     Value
-	name    *nameHelper
-	pointer bool
-}
-
-// Pointer turns the cast value into a pointer
-func (c *castValue) Pointer() *castValue {
-	c.pointer = true
-	return c
+	val  Value
+	name *nameHelper
 }
 
 func newCastValue(val Value, alias, typeName string, isPointer bool) *castValue {
@@ -35,5 +28,5 @@ func (c *castValue) writeValue(sb *strings.Builder) {
 }
 
 func (c *castValue) isPointer() bool {
-	return c.pointer
+	return false
 }

--- a/value_cast_test.go
+++ b/value_cast_test.go
@@ -1,0 +1,28 @@
+package codegen
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCastType(t *testing.T) {
+	const want = `a.(string)`
+
+	var sb strings.Builder
+	newCastValue(Identifier("a"), "", "string", false).
+		writeValue(&sb)
+
+	assert.Equal(t, want, sb.String())
+}
+
+func TestCastTypePointer(t *testing.T) {
+	const want = `a.(*string)`
+
+	var sb strings.Builder
+	newCastValue(Identifier("a"), "", "string", true).
+		writeValue(&sb)
+
+	assert.Equal(t, want, sb.String())
+}

--- a/value_cast_test.go
+++ b/value_cast_test.go
@@ -26,3 +26,30 @@ func TestCastTypePointer(t *testing.T) {
 
 	assert.Equal(t, want, sb.String())
 }
+
+func TestCastQualType(t *testing.T) {
+	const want = `a.(alias.MyType)`
+
+	var sb strings.Builder
+	newCastValue(Identifier("a"), "alias", "MyType", false).
+		writeValue(&sb)
+
+	assert.Equal(t, want, sb.String())
+}
+
+func TestCastQualTypePointer(t *testing.T) {
+	const want = `a.(*alias.MyType)`
+
+	var sb strings.Builder
+	newCastValue(Identifier("a"), "alias", "MyType", true).
+		writeValue(&sb)
+
+	assert.Equal(t, want, sb.String())
+}
+
+func TestCastNotPointer(t *testing.T) {
+	got := newCastValue(Identifier("a"), "alias", "MyType", true).
+		isPointer()
+
+	assert.False(t, got)
+}

--- a/value_field.go
+++ b/value_field.go
@@ -17,6 +17,26 @@ func (f *fieldValue) Call(name string) *callValue {
 	return newCallValue(f, name)
 }
 
+// Cast casts the field to the specified type
+func (f *fieldValue) Cast(typeName string) *castValue {
+	return newCastValue(f, "", typeName, false)
+}
+
+// CastPointer casts the field to a pointer of the specified type
+func (f *fieldValue) CastPointer(typeName string) *castValue {
+	return newCastValue(f, "", typeName, true)
+}
+
+// CastQual casts the field to the specified type with an alias
+func (f *fieldValue) CastQual(alias, typeName string) *castValue {
+	return newCastValue(f, alias, typeName, false)
+}
+
+// CastQualPointer casts the field to a pointer of the specified type with an alias
+func (f *fieldValue) CastQualPointer(alias, typeName string) *castValue {
+	return newCastValue(f, alias, typeName, true)
+}
+
 // Assign assigns a value to the field
 func (f *fieldValue) Assign(val Value) *assignStmt {
 	return newAssignment(f, val)

--- a/value_field_test.go
+++ b/value_field_test.go
@@ -62,3 +62,47 @@ func TestIdentifierFieldCallArgs(t *testing.T) {
 
 	assert.Equal(t, want, sb.String())
 }
+
+func TestFieldCast(t *testing.T) {
+	const want = `obj.field.(string)`
+
+	var sb strings.Builder
+	Identifier("obj").
+		Field("field").Cast("string").
+		writeValue(&sb)
+
+	assert.Equal(t, want, sb.String())
+}
+
+func TestFieldCastPointer(t *testing.T) {
+	const want = `obj.field.(*string)`
+
+	var sb strings.Builder
+	Identifier("obj").
+		Field("field").CastPointer("string").
+		writeValue(&sb)
+
+	assert.Equal(t, want, sb.String())
+}
+
+func TestFieldCastQual(t *testing.T) {
+	const want = `obj.field.(alias.MyType)`
+
+	var sb strings.Builder
+	Identifier("obj").
+		Field("field").CastQual("alias", "MyType").
+		writeValue(&sb)
+
+	assert.Equal(t, want, sb.String())
+}
+
+func TestFieldCastQualPointer(t *testing.T) {
+	const want = `obj.field.(*alias.MyType)`
+
+	var sb strings.Builder
+	Identifier("obj").
+		Field("field").CastQualPointer("alias", "MyType").
+		writeValue(&sb)
+
+	assert.Equal(t, want, sb.String())
+}

--- a/value_funcCall.go
+++ b/value_funcCall.go
@@ -18,26 +18,46 @@ func QualFuncCall(alias, name string) *funcCallValue {
 	return newFuncCall(alias, name)
 }
 
-// Pointer turns the value to a pointer type
-func (q *funcCallValue) Pointer() *funcCallValue {
-	q.isPtr = true
-	return q
+// Pointer dereferences the return value of the function
+func (f *funcCallValue) Pointer() *funcCallValue {
+	f.isPtr = true
+	return f
 }
 
 // Args appeng argument for the function call
-func (q *funcCallValue) Args(args ...Value) *funcCallValue {
-	q.args = args
-	return q
+func (f *funcCallValue) Args(args ...Value) *funcCallValue {
+	f.args = args
+	return f
 }
 
 // Field appends a new field getter after the function call
-func (q *funcCallValue) Field(fieldName string) *fieldValue {
-	return newField(q, fieldName)
+func (f *funcCallValue) Field(fieldName string) *fieldValue {
+	return newField(f, fieldName)
 }
 
 // Call appends a new function call after the function call
-func (q *funcCallValue) Call(funcName string) *callValue {
-	return newCallValue(q, funcName)
+func (f *funcCallValue) Call(funcName string) *callValue {
+	return newCallValue(f, funcName)
+}
+
+// Cast casts the function return value to the specified type
+func (f *funcCallValue) Cast(typeName string) *castValue {
+	return newCastValue(f, "", typeName, false)
+}
+
+// CastPointer casts thefunction return value to a pointer of the specified type
+func (f *funcCallValue) CastPointer(typeName string) *castValue {
+	return newCastValue(f, "", typeName, true)
+}
+
+// CastQual casts the function return value to the specified type with an alias
+func (f *funcCallValue) CastQual(alias, typeName string) *castValue {
+	return newCastValue(f, alias, typeName, false)
+}
+
+// CastQualPointer casts thefunction return value to a pointer of the specified type with an alias
+func (f *funcCallValue) CastQualPointer(alias, typeName string) *castValue {
+	return newCastValue(f, alias, typeName, true)
 }
 
 func newFuncCall(alias, name string) *funcCallValue {

--- a/value_funcCall_test.go
+++ b/value_funcCall_test.go
@@ -158,3 +158,93 @@ func TestQualFuncCallCallArgs(t *testing.T) {
 
 	assert.Equal(t, want, sb.String())
 }
+
+func TestFuncCallCast(t *testing.T) {
+	const want = `myFunc().(string)`
+
+	var sb strings.Builder
+	FuncCall("myFunc").Cast("string").
+		writeValue(&sb)
+
+	assert.Equal(t, want, sb.String())
+}
+
+func TestFuncCallPointerCast(t *testing.T) {
+	const want = `(*myFunc()).(string)`
+
+	var sb strings.Builder
+	FuncCall("myFunc").Pointer().Cast("string").
+		writeValue(&sb)
+
+	assert.Equal(t, want, sb.String())
+}
+
+func TestFuncCallCastPointer(t *testing.T) {
+	const want = `myFunc().(*string)`
+
+	var sb strings.Builder
+	FuncCall("myFunc").CastPointer("string").
+		writeValue(&sb)
+
+	assert.Equal(t, want, sb.String())
+}
+
+func TestFuncCallPointerCastPointer(t *testing.T) {
+	const want = `(*myFunc()).(*string)`
+
+	var sb strings.Builder
+	FuncCall("myFunc").Pointer().CastPointer("string").
+		writeValue(&sb)
+
+	assert.Equal(t, want, sb.String())
+}
+
+func TestFuncCallCastQual(t *testing.T) {
+	const want = `myFunc().(alias.MyType)`
+
+	var sb strings.Builder
+	FuncCall("myFunc").CastQual("alias", "MyType").
+		writeValue(&sb)
+
+	assert.Equal(t, want, sb.String())
+}
+
+func TestFuncCallPointerCastQual(t *testing.T) {
+	const want = `(*myFunc()).(alias.MyType)`
+
+	var sb strings.Builder
+	FuncCall("myFunc").Pointer().CastQual("alias", "MyType").
+		writeValue(&sb)
+
+	assert.Equal(t, want, sb.String())
+}
+
+func TestFuncCallCastQualPointer(t *testing.T) {
+	const want = `myFunc().(*alias.MyType)`
+
+	var sb strings.Builder
+	FuncCall("myFunc").CastQualPointer("alias", "MyType").
+		writeValue(&sb)
+
+	assert.Equal(t, want, sb.String())
+}
+
+func TestFuncCallPointerCastQualPointer(t *testing.T) {
+	const want = `(*myFunc()).(*alias.MyType)`
+
+	var sb strings.Builder
+	FuncCall("myFunc").Pointer().CastQualPointer("alias", "MyType").
+		writeValue(&sb)
+
+	assert.Equal(t, want, sb.String())
+}
+
+func TestQualFuncCallCast(t *testing.T) {
+	const want = `alias.MyFunc(a,b).(string)`
+
+	var sb strings.Builder
+	QualFuncCall("alias", "MyFunc").Args(Identifier("a"), Identifier("b")).
+		Cast("string").writeValue(&sb)
+
+	assert.Equal(t, want, sb.String())
+}

--- a/value_identifier.go
+++ b/value_identifier.go
@@ -24,7 +24,7 @@ func QualIdentifier(alias, name string) *identifierValue {
 	}
 }
 
-// Pointer turns the identifier into a pointer type
+// Pointer dereferences the identifier
 func (i *identifierValue) Pointer() *identifierValue {
 	i.SetIsPointer(true)
 	return i
@@ -70,6 +70,26 @@ func (i *identifierValue) Field(fieldName string) *fieldValue {
 // Call appends a new function call after the identifier
 func (i *identifierValue) Call(funcName string) *callValue {
 	return newCallValue(i, funcName)
+}
+
+// Cast casts the identifier to the specified type
+func (i *identifierValue) Cast(typeName string) *castValue {
+	return newCastValue(i, "", typeName, false)
+}
+
+// CastPointer casts the identifier to a pointer of the specified type
+func (i *identifierValue) CastPointer(typeName string) *castValue {
+	return newCastValue(i, "", typeName, true)
+}
+
+// CastQual casts the identifier to the specified type with an alias
+func (i *identifierValue) CastQual(alias, typeName string) *castValue {
+	return newCastValue(i, alias, typeName, false)
+}
+
+// CastPointer casts the identifier to a pointer of the specified type with an alias
+func (i *identifierValue) CastQualPointer(alias, typeName string) *castValue {
+	return newCastValue(i, alias, typeName, true)
 }
 
 // Assign assigns a value to the identifier

--- a/value_identifier_test.go
+++ b/value_identifier_test.go
@@ -286,3 +286,83 @@ func TestIdentifierSetIsPointerFalse(t *testing.T) {
 
 	assert.Equal(t, want, sb.String())
 }
+
+func TestIdentifierCast(t *testing.T) {
+	const want = `a.(string)`
+
+	var sb strings.Builder
+	Identifier("a").Cast("string").
+		writeValue(&sb)
+
+	assert.Equal(t, want, sb.String())
+}
+
+func TestIdentifierPointerCast(t *testing.T) {
+	const want = `(*a).(string)`
+
+	var sb strings.Builder
+	Identifier("a").Pointer().Cast("string").
+		writeValue(&sb)
+
+	assert.Equal(t, want, sb.String())
+}
+
+func TestIdentifierCastPointer(t *testing.T) {
+	const want = `a.(*string)`
+
+	var sb strings.Builder
+	Identifier("a").CastPointer("string").
+		writeValue(&sb)
+
+	assert.Equal(t, want, sb.String())
+}
+
+func TestIdentifierPointerCastPointer(t *testing.T) {
+	const want = `(*a).(*string)`
+
+	var sb strings.Builder
+	Identifier("a").Pointer().CastPointer("string").
+		writeValue(&sb)
+
+	assert.Equal(t, want, sb.String())
+}
+
+func TestIdentifierCastQual(t *testing.T) {
+	const want = `a.(alias.MyType)`
+
+	var sb strings.Builder
+	Identifier("a").CastQual("alias", "MyType").
+		writeValue(&sb)
+
+	assert.Equal(t, want, sb.String())
+}
+
+func TestIdentifierPointerCastQual(t *testing.T) {
+	const want = `(*a).(alias.MyType)`
+
+	var sb strings.Builder
+	Identifier("a").Pointer().CastQual("alias", "MyType").
+		writeValue(&sb)
+
+	assert.Equal(t, want, sb.String())
+}
+
+func TestIdentifierCastQualPointer(t *testing.T) {
+	const want = `a.(*alias.MyType)`
+
+	var sb strings.Builder
+	Identifier("a").CastQualPointer("alias", "MyType").
+		writeValue(&sb)
+
+	assert.Equal(t, want, sb.String())
+}
+
+func TestIdentifierPointerCastQualPointer(t *testing.T) {
+	const want = `(*a).(*alias.MyType)`
+
+	var sb strings.Builder
+	Identifier("a").Pointer().CastQualPointer("alias", "MyType").
+		writeValue(&sb)
+
+	assert.Equal(t, want, sb.String())
+}


### PR DESCRIPTION
Issue #37
- cast for `Identifier`
- cast for `FuncCall`
- cast for `Field`
- cast for `Call`