### PR TITLE
expose some props with getters

### DIFF
--- a/block_funcParam.go
+++ b/block_funcParam.go
@@ -14,6 +14,16 @@ func (p *ParamDecl) Name() string {
 
 // TypeName gets the type name of the parameter
 func (p *ParamDecl) TypeName() string {
+	return p.typeName.identifier
+}
+
+// TypeAlias return an alias of the type package (if any) from there the type is imported
+func (p *ParamDecl) TypeAlias() string {
+	return p.typeName.alias
+}
+
+// FullType gets the full string representation of the type
+func (p *ParamDecl) FullType() string {
 	var sb strings.Builder
 	p.typeName.writeValue(&sb)
 

--- a/block_funcParam.go
+++ b/block_funcParam.go
@@ -7,23 +7,23 @@ type ParamDecl struct {
 	typeName *nameHelper
 }
 
-// Name gets the name of the parameter
-func (p *ParamDecl) Name() string {
+// GetName gets the name of the parameter
+func (p *ParamDecl) GetName() string {
 	return p.name
 }
 
-// TypeName gets the type name of the parameter
-func (p *ParamDecl) TypeName() string {
+// GetTypeName gets the type name of the parameter
+func (p *ParamDecl) GetTypeName() string {
 	return p.typeName.identifier
 }
 
-// TypeAlias return an alias of the type package (if any) from there the type is imported
-func (p *ParamDecl) TypeAlias() string {
+// GetTypeAlias return an alias of the type package (if any) from there the type is imported
+func (p *ParamDecl) GetTypeAlias() string {
 	return p.typeName.alias
 }
 
-// FullType gets the full string representation of the type
-func (p *ParamDecl) FullType() string {
+// GetFullType gets the full string representation of the type
+func (p *ParamDecl) GetFullType() string {
 	var sb strings.Builder
 	p.typeName.writeValue(&sb)
 

--- a/block_funcParam_test.go
+++ b/block_funcParam_test.go
@@ -14,37 +14,37 @@ func TestParamName(t *testing.T) {
 	assert.Equal(t, want, got)
 }
 
-func TestQualParamName(t *testing.T) {
+func TestQualParamFullName(t *testing.T) {
 	const want = `name`
 	got := QualParam("name", "alias", "typeName").Name()
 
 	assert.Equal(t, want, got)
 }
 
-func TestParamType(t *testing.T) {
+func TestParamFullType(t *testing.T) {
 	const want = `typeName`
-	got := Param("name", "typeName").TypeName()
+	got := Param("name", "typeName").FullType()
 
 	assert.Equal(t, want, got)
 }
 
-func TestQualParamType(t *testing.T) {
+func TestQualParamFullType(t *testing.T) {
 	const want = `alias.typeName`
-	got := QualParam("name", "alias", "typeName").TypeName()
+	got := QualParam("name", "alias", "typeName").FullType()
 
 	assert.Equal(t, want, got)
 }
 
-func TestParamTypePointer(t *testing.T) {
+func TestParamFullTypePointer(t *testing.T) {
 	const want = `*typeName`
-	got := Param("name", "typeName").Pointer().TypeName()
+	got := Param("name", "typeName").Pointer().FullType()
 
 	assert.Equal(t, want, got)
 }
 
 func TestQualParamTypePointer(t *testing.T) {
 	const want = `*alias.typeName`
-	got := QualParam("name", "alias", "typeName").Pointer().TypeName()
+	got := QualParam("name", "alias", "typeName").Pointer().FullType()
 
 	assert.Equal(t, want, got)
 }
@@ -124,7 +124,7 @@ func TestFuncParams(t *testing.T) {
 	assert.Equal(t, want, sb.String())
 }
 
-func TestPuncParamSetIsPointerTrue(t *testing.T) {
+func TestFuncParamSetIsPointerTrue(t *testing.T) {
 	const want = `(name1 *type)`
 
 	var sb strings.Builder
@@ -136,7 +136,7 @@ func TestPuncParamSetIsPointerTrue(t *testing.T) {
 	assert.Equal(t, want, sb.String())
 }
 
-func TestPuncParamSetIsPointerFalse(t *testing.T) {
+func TestFuncParamSetIsPointerFalse(t *testing.T) {
 	const want = `(name1 type)`
 
 	var sb strings.Builder
@@ -146,4 +146,12 @@ func TestPuncParamSetIsPointerFalse(t *testing.T) {
 	writeParams(&sb, params)
 
 	assert.Equal(t, want, sb.String())
+}
+
+func TestFuncGetters(t *testing.T) {
+	fixture := QualParam("param", "alias", "MyType")
+
+	assert.Equal(t, fixture.Name(), "param")
+	assert.Equal(t, fixture.TypeAlias(), "alias")
+	assert.Equal(t, fixture.TypeName(), "MyType")
 }

--- a/block_funcParam_test.go
+++ b/block_funcParam_test.go
@@ -9,42 +9,42 @@ import (
 
 func TestParamName(t *testing.T) {
 	const want = `name`
-	got := Param("name", "typeName").Name()
+	got := Param("name", "typeName").GetName()
 
 	assert.Equal(t, want, got)
 }
 
 func TestQualParamFullName(t *testing.T) {
 	const want = `name`
-	got := QualParam("name", "alias", "typeName").Name()
+	got := QualParam("name", "alias", "typeName").GetName()
 
 	assert.Equal(t, want, got)
 }
 
 func TestParamFullType(t *testing.T) {
 	const want = `typeName`
-	got := Param("name", "typeName").FullType()
+	got := Param("name", "typeName").GetFullType()
 
 	assert.Equal(t, want, got)
 }
 
 func TestQualParamFullType(t *testing.T) {
 	const want = `alias.typeName`
-	got := QualParam("name", "alias", "typeName").FullType()
+	got := QualParam("name", "alias", "typeName").GetFullType()
 
 	assert.Equal(t, want, got)
 }
 
 func TestParamFullTypePointer(t *testing.T) {
 	const want = `*typeName`
-	got := Param("name", "typeName").Pointer().FullType()
+	got := Param("name", "typeName").Pointer().GetFullType()
 
 	assert.Equal(t, want, got)
 }
 
 func TestQualParamTypePointer(t *testing.T) {
 	const want = `*alias.typeName`
-	got := QualParam("name", "alias", "typeName").Pointer().FullType()
+	got := QualParam("name", "alias", "typeName").Pointer().GetFullType()
 
 	assert.Equal(t, want, got)
 }
@@ -151,7 +151,7 @@ func TestFuncParamSetIsPointerFalse(t *testing.T) {
 func TestFuncGetters(t *testing.T) {
 	fixture := QualParam("param", "alias", "MyType")
 
-	assert.Equal(t, fixture.Name(), "param")
-	assert.Equal(t, fixture.TypeAlias(), "alias")
-	assert.Equal(t, fixture.TypeName(), "MyType")
+	assert.Equal(t, fixture.GetName(), "param")
+	assert.Equal(t, fixture.GetTypeAlias(), "alias")
+	assert.Equal(t, fixture.GetTypeName(), "MyType")
 }

--- a/block_funcReturnType.go
+++ b/block_funcReturnType.go
@@ -3,17 +3,17 @@ package codegen
 import "strings"
 
 type ReturnTypeDecl struct {
-	name *nameHelper
+	*nameHelper
 }
 
 // ReturnType creates a new return type for a function
 func ReturnType(name string) *ReturnTypeDecl {
-	return &ReturnTypeDecl{name: newNameHelper("", name)}
+	return &ReturnTypeDecl{nameHelper: newNameHelper("", name)}
 }
 
 // QualReturnType creates a new return type with an alias of an imported package
 func QualReturnType(alias, name string) *ReturnTypeDecl {
-	return &ReturnTypeDecl{name: newNameHelper(alias, name)}
+	return &ReturnTypeDecl{nameHelper: newNameHelper(alias, name)}
 }
 
 // ReturnTypeError create a new return type of type `error`
@@ -29,12 +29,12 @@ func (r *ReturnTypeDecl) Pointer() *ReturnTypeDecl {
 
 // SetIsPointer sets whether or not a return type is a pointer
 func (r *ReturnTypeDecl) SetIsPointer(isPointer bool) *ReturnTypeDecl {
-	r.name.pointer(isPointer)
+	r.nameHelper.pointer(isPointer)
 	return r
 }
 
 func (r *ReturnTypeDecl) wr(sb *strings.Builder) {
-	r.name.writeValue(sb)
+	r.nameHelper.writeValue(sb)
 }
 
 func writeReturnTypes(sb *strings.Builder, returnTypes []*ReturnTypeDecl) {

--- a/block_funcReturnType.go
+++ b/block_funcReturnType.go
@@ -6,13 +6,13 @@ type ReturnTypeDecl struct {
 	name *nameHelper
 }
 
-// TypeName gets a type name of the return declaration
-func (r *ReturnTypeDecl) TypeName() string {
+// GetTypeName gets a type name of the return declaration
+func (r *ReturnTypeDecl) GetTypeName() string {
 	return r.name.identifier
 }
 
-// TypeAlias gets a type alias (if any) of the return declaration
-func (r *ReturnTypeDecl) TypeAlias() string {
+// GetTypeAlias gets a type alias (if any) of the return declaration
+func (r *ReturnTypeDecl) GetTypeAlias() string {
 	return r.name.alias
 }
 

--- a/block_funcReturnType.go
+++ b/block_funcReturnType.go
@@ -3,17 +3,27 @@ package codegen
 import "strings"
 
 type ReturnTypeDecl struct {
-	*nameHelper
+	name *nameHelper
+}
+
+// TypeName gets a type name of the return declaration
+func (r *ReturnTypeDecl) TypeName() string {
+	return r.name.identifier
+}
+
+// TypeAlias gets a type alias (if any) of the return declaration
+func (r *ReturnTypeDecl) TypeAlias() string {
+	return r.name.alias
 }
 
 // ReturnType creates a new return type for a function
 func ReturnType(name string) *ReturnTypeDecl {
-	return &ReturnTypeDecl{nameHelper: newNameHelper("", name)}
+	return &ReturnTypeDecl{name: newNameHelper("", name)}
 }
 
 // QualReturnType creates a new return type with an alias of an imported package
 func QualReturnType(alias, name string) *ReturnTypeDecl {
-	return &ReturnTypeDecl{nameHelper: newNameHelper(alias, name)}
+	return &ReturnTypeDecl{name: newNameHelper(alias, name)}
 }
 
 // ReturnTypeError create a new return type of type `error`
@@ -29,12 +39,12 @@ func (r *ReturnTypeDecl) Pointer() *ReturnTypeDecl {
 
 // SetIsPointer sets whether or not a return type is a pointer
 func (r *ReturnTypeDecl) SetIsPointer(isPointer bool) *ReturnTypeDecl {
-	r.nameHelper.pointer(isPointer)
+	r.name.pointer(isPointer)
 	return r
 }
 
 func (r *ReturnTypeDecl) wr(sb *strings.Builder) {
-	r.nameHelper.writeValue(sb)
+	r.name.writeValue(sb)
 }
 
 func writeReturnTypes(sb *strings.Builder, returnTypes []*ReturnTypeDecl) {

--- a/block_funcReturnType_test.go
+++ b/block_funcReturnType_test.go
@@ -116,6 +116,6 @@ func TestFuncReturnTypeSetIsPointerFalse(t *testing.T) {
 func TestReturnParamGetters(t *testing.T) {
 	fixture := QualReturnType("alias", "MyType")
 
-	assert.Equal(t, "alias", fixture.Alias())
-	assert.Equal(t, "MyType", fixture.Identifier())
+	assert.Equal(t, "alias", fixture.TypeAlias())
+	assert.Equal(t, "MyType", fixture.TypeName())
 }

--- a/block_funcReturnType_test.go
+++ b/block_funcReturnType_test.go
@@ -112,3 +112,10 @@ func TestFuncReturnTypeSetIsPointerFalse(t *testing.T) {
 
 	assert.Equal(t, want, sb.String())
 }
+
+func TestReturnParamGetters(t *testing.T) {
+	fixture := QualReturnType("alias", "MyType")
+
+	assert.Equal(t, "alias", fixture.Alias())
+	assert.Equal(t, "MyType", fixture.Identifier())
+}

--- a/block_funcReturnType_test.go
+++ b/block_funcReturnType_test.go
@@ -116,6 +116,6 @@ func TestFuncReturnTypeSetIsPointerFalse(t *testing.T) {
 func TestReturnParamGetters(t *testing.T) {
 	fixture := QualReturnType("alias", "MyType")
 
-	assert.Equal(t, "alias", fixture.TypeAlias())
-	assert.Equal(t, "MyType", fixture.TypeName())
+	assert.Equal(t, "alias", fixture.GetTypeAlias())
+	assert.Equal(t, "MyType", fixture.GetTypeName())
 }

--- a/help_name.go
+++ b/help_name.go
@@ -8,16 +8,6 @@ type nameHelper struct {
 	isPointer  bool
 }
 
-// Alias returns an alias of the name
-func (n *nameHelper) Alias() string {
-	return n.alias
-}
-
-// Identifier returns an identifier of the name
-func (n *nameHelper) Identifier() string {
-	return n.identifier
-}
-
 func newNameHelper(alias, identifier string) *nameHelper {
 	return &nameHelper{alias: alias, identifier: identifier}
 }

--- a/help_name.go
+++ b/help_name.go
@@ -8,6 +8,16 @@ type nameHelper struct {
 	isPointer  bool
 }
 
+// Alias returns an alias of the name
+func (n *nameHelper) Alias() string {
+	return n.alias
+}
+
+// Identifier returns an identifier of the name
+func (n *nameHelper) Identifier() string {
+	return n.identifier
+}
+
 func newNameHelper(alias, identifier string) *nameHelper {
 	return &nameHelper{alias: alias, identifier: identifier}
 }


### PR DESCRIPTION
NB!
getter names does not comply with go standards, but it's a way to distinguish them from init methods. Init methods just have a name of what they init (convention for getters) 